### PR TITLE
remove hrana1 tests since it's not supported anymore

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,8 +32,6 @@ jobs:
       with:
         repository: "libsql/hrana-test-server"
         path: "hrana-test-server"
-    - name: "Test with server v1"
-      run: "poetry run python hrana-test-server/server_v1.py pytest --ignore tests/dbapi2 --verbose"
     - name: "Test with server v2 (reduced < python-3.11)"
       if: ${{ matrix.python-version != '3.11' }}
       run: "poetry run python hrana-test-server/server_v2.py pytest --ignore tests/dbapi2 --verbose"


### PR DESCRIPTION
hrana2 is backward compatible and more capable, it's easy to migrate to it, so let's just stop handling (and testing) hrana1