### PR TITLE
Add support for ?tls=0 query parameter

### DIFF
--- a/libsql_client/config.py
+++ b/libsql_client/config.py
@@ -12,9 +12,12 @@ class _Config(NamedTuple):
     authority: str
     path: str
     auth_token: Optional[str]
+    tls: bool
 
 
-def _expand_config(url: str, *, auth_token: Optional[str]) -> _Config:
+def _expand_config(
+    url: str, *, auth_token: Optional[str], tls: Optional[bool]
+) -> _Config:
     url_parsed = urllib.parse.urlparse(url)
     scheme = url_parsed.scheme
     authority = url_parsed.netloc
@@ -24,10 +27,37 @@ def _expand_config(url: str, *, auth_token: Optional[str]) -> _Config:
     for key, value in qsl:
         if key == "authToken":
             auth_token = value or None
+        elif key == "tls":
+            if value == "0":
+                tls = False
+            elif value == "1":
+                tls = True
+            else:
+                raise LibsqlError(
+                    f"Unknown value for the 'tls' query argument: {value!r}. "
+                    "Supported values are '0' and '1'",
+                    "URL_INVALID",
+                )
         else:
             raise LibsqlError(
                 f"Unknown URL query parameter {key!r}", "URL_PARAM_NOT_SUPPORTED"
             )
+
+    if scheme == "libsql":
+        if tls is False:
+            if url_parsed.port is None:
+                raise LibsqlError(
+                    "A 'libsql:' URL with ?tls=0 must specify an explicit port",
+                    "URL_INVALID",
+                )
+            scheme = "ws"
+        else:
+            scheme = "wss"
+    elif scheme in ("http", "ws") and tls is None:
+        tls = False
+
+    if tls is None:
+        tls = True
 
     if url_parsed.params:
         raise LibsqlError(
@@ -38,4 +68,4 @@ def _expand_config(url: str, *, auth_token: Optional[str]) -> _Config:
             f"Unsupported URL fragment: {url_parsed.fragment!r}", "URL_INVALID"
         )
 
-    return _Config(scheme, authority, path, auth_token)
+    return _Config(scheme, authority, path, auth_token, tls)

--- a/libsql_client/create_client.py
+++ b/libsql_client/create_client.py
@@ -10,11 +10,10 @@ from .http import _create_http_client
 from .sqlite3 import _create_sqlite3_client
 
 
-def create_client(url: str, *, auth_token: Optional[str] = None) -> Client:
-    config = _expand_config(url, auth_token=auth_token)
-    if config.scheme == "libsql":
-        config = config._replace(scheme="wss")
-
+def create_client(
+    url: str, *, auth_token: Optional[str] = None, tls: Optional[bool] = None
+) -> Client:
+    config = _expand_config(url, auth_token=auth_token, tls=tls)
     if config.scheme == "file":
         return _create_sqlite3_client(config)
     elif config.scheme in ("ws", "wss"):

--- a/libsql_client/hrana/client.py
+++ b/libsql_client/hrana/client.py
@@ -26,6 +26,15 @@ from ..result import ResultSet
 
 def _create_hrana_client(config: _Config) -> HranaClient:
     assert config.scheme in ("ws", "wss")
+    if config.scheme == "ws" and config.tls:
+        raise LibsqlError(
+            "A 'ws:' URL cannot opt into TLS by using ?tls=1", "URL_INVALID"
+        )
+    elif config.scheme == "wss" and not config.tls:
+        raise LibsqlError(
+            "A 'wss:' URL cannot opt out of TLS by using ?tls=0", "URL_INVALID"
+        )
+
     url = urllib.parse.urlunparse(
         (
             config.scheme,

--- a/libsql_client/hrana/client.py
+++ b/libsql_client/hrana/client.py
@@ -26,6 +26,11 @@ from ..result import ResultSet
 
 def _create_hrana_client(config: _Config) -> HranaClient:
     assert config.scheme in ("ws", "wss")
+    url = _config_to_url(config)
+    return HranaClient(url, config.auth_token)
+
+
+def _config_to_url(config: _Config) -> str:
     if config.scheme == "ws" and config.tls:
         raise LibsqlError(
             "A 'ws:' URL cannot opt into TLS by using ?tls=1", "URL_INVALID"
@@ -35,7 +40,7 @@ def _create_hrana_client(config: _Config) -> HranaClient:
             "A 'wss:' URL cannot opt out of TLS by using ?tls=0", "URL_INVALID"
         )
 
-    url = urllib.parse.urlunparse(
+    return urllib.parse.urlunparse(
         (
             config.scheme,
             config.authority,
@@ -45,7 +50,6 @@ def _create_hrana_client(config: _Config) -> HranaClient:
             "",
         )
     )
-    return HranaClient(url, config.auth_token)
 
 
 class HranaClient(Client):

--- a/libsql_client/http.py
+++ b/libsql_client/http.py
@@ -25,6 +25,15 @@ from .result import ResultSet
 
 def _create_http_client(config: _Config) -> HttpClient:
     assert config.scheme in ("http", "https")
+    if config.scheme == "http" and config.tls:
+        raise LibsqlError(
+            "A 'http:' URL cannot opt into TLS by using ?tls=1", "URL_INVALID"
+        )
+    elif config.scheme == "https" and not config.tls:
+        raise LibsqlError(
+            "A 'https:' URL cannot opt out of TLS by using ?tls=0", "URL_INVALID"
+        )
+
     url = urllib.parse.urlunparse(
         (
             config.scheme,

--- a/tests/test_create_client.py
+++ b/tests/test_create_client.py
@@ -38,3 +38,31 @@ def test_error_url_param_not_supported():
         libsql_client.create_client("ws://localhost?foo=bar")
     assert excinfo.value.code == "URL_PARAM_NOT_SUPPORTED"
     assert "foo" in str(excinfo.value)
+
+
+def test_error_url_scheme_incompatible_with_tls():
+    urls = [
+        "ws://localhost?tls=1",
+        "wss://localhost?tls=0",
+        "http://localhost?tls=1",
+        "https://localhost?tls=0",
+    ]
+    for url in urls:
+        with pytest.raises(libsql_client.LibsqlError) as excinfo:
+            libsql_client.create_client(url)
+        assert excinfo.value.code == "URL_INVALID"
+        assert "tls" in str(excinfo.value)
+
+
+def test_error_invalid_value_of_tls():
+    with pytest.raises(libsql_client.LibsqlError) as excinfo:
+        libsql_client.create_client("libsql://localhost?tls=foo")
+    assert excinfo.value.code == "URL_INVALID"
+    assert "foo" in str(excinfo.value)
+
+
+def test_missing_port_in_libsql_url_without_tls():
+    with pytest.raises(libsql_client.LibsqlError) as excinfo:
+        libsql_client.create_client("libsql://localhost?tls=0")
+    assert excinfo.value.code == "URL_INVALID"
+    assert "port" in str(excinfo.value)


### PR DESCRIPTION
This parameter can be used to opt out of TLS when using `libsql:` URL. It is also possible to use it with HTTP and WebSocket URLs, but in this case we just check that it matches the existing scheme (i.e., `https://localhost?tls=0` throws an error). We also require every `libsql:` URL with `?tls=0` to specify an explicit port, because the default port for `libsql:` URL is 443, which could produce unexpected results.