### PR TITLE
feat(libsqlerror): add explanation field that details error

### DIFF
--- a/libsql_client/client.py
+++ b/libsql_client/client.py
@@ -56,10 +56,12 @@ class Statement:
 
 class LibsqlError(RuntimeError):
     code: str
+    explanation: str
 
     def __init__(self, message: str, code: str):
         super(RuntimeError, self).__init__(f"{code}: {message}")
         self.code = code
+        self.explanation = message
 
 
 TClient = TypeVar("TClient", bound="Client")


### PR DESCRIPTION
- same value as message. The different name is so that it doesn't conflict with a property on the BaseException called message
- before this, to find more info on the error, the dev would have to call .args, which is not ideal

Issue: https://github.com/libsql/libsql-client-py/issues/15