### PR TITLE
add error handling for no URL

### DIFF
--- a/libsql_client/create_client.py
+++ b/libsql_client/create_client.py
@@ -20,6 +20,10 @@ def create_client(
         return _create_hrana_client(config)
     elif config.scheme in ("http", "https"):
         return _create_http_client(config)
+    elif not url:
+        raise LibsqlError(
+            f"Database URL is {url}.", "URL_UNDEFINED"
+        )
     else:
         raise LibsqlError(
             f"Unsupported URL scheme {config.scheme!r}", "URL_SCHEME_NOT_SUPPORTED"


### PR DESCRIPTION
This PR attempts to add error handling when a remote database URL is `undefined` related to issue [https://github.com/libsql/libsql-client-py/issues/19](url).

If this might be helpful please consider merging. If not, feel free to close. Thank you.